### PR TITLE
Replace maven dependency

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -63,7 +63,7 @@ After adding the snapshot repository feel free to add the Maven dependency:
 ```xml
 <dependency>
     <groupId>com.agrirouter.proto</groupId>
-    <artifactId>definitions</artifactId>
+    <artifactId>agrirouter-api-protobuf-definitions</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <classifier>jdk10</classifier>
 </dependency>
@@ -78,7 +78,7 @@ After adding the snapshot repository feel free to add the following Maven depend
 ```xml
 <dependency>
     <groupId>com.agrirouter.proto</groupId>
-    <artifactId>definitions</artifactId>
+    <artifactId>agrirouter-api-protobuf-definitions</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <classifier>jdk8</classifier>
 </dependency>
@@ -91,7 +91,7 @@ After adding the snapshot repository feel free to add the following Maven depend
 ```xml
 <dependency>
     <groupId>com.agrirouter.proto</groupId>
-    <artifactId>definitions</artifactId>
+    <artifactId>agrirouter-api-protobuf-definitions</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <classifier>jdk9</classifier>
 </dependency>
@@ -104,7 +104,7 @@ After adding the snapshot repository feel free to add the following Maven depend
 ```xml
 <dependency>
     <groupId>com.agrirouter.proto</groupId>
-    <artifactId>definitions</artifactId>
+    <artifactId>agrirouter-api-protobuf-definitions</artifactId>
     <version>0.0.1-SNAPSHOT</version>
     <classifier>jdk10</classifier>
 </dependency>

--- a/README.adoc
+++ b/README.adoc
@@ -75,6 +75,7 @@ Currently we are supporting JDK 8, JDK 9 and JDK 10 by using classifiers.
 
 After adding the snapshot repository feel free to add the following Maven dependency:
 
+
 ```xml
 <dependency>
     <groupId>com.agrirouter.proto</groupId>


### PR DESCRIPTION
Replaced in maven dependency definitions with agrirouter-api-protobuf-definitions because definitions do not have the classifiers

https://oss.sonatype.org/content/repositories/snapshots/com/agrirouter/proto/agrirouter-api-protobuf-definitions/0.0.1-SNAPSHOT/
vs.
https://oss.sonatype.org/content/repositories/snapshots/com/agrirouter/proto/definitions/0.0.1-SNAPSHOT/

Maven artifact definitions is not used anymore since Thu Aug 16 14:05:40 UTC 2018


=====
Original commit by Manuel Blechschmidt in PullRequest 30, but not verified